### PR TITLE
Add escaping function to avoid errors when generating variant

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 const pseudoElements = require('./pseudo-elements')
 
-module.exports = function({addVariant}) {
+module.exports = function({addVariant, e}) {
   pseudoElements.forEach(pseudo => {
     addVariant(pseudo, ({modifySelectors, separator}) => {
       modifySelectors(({className}) => {
-        return `.${pseudo}${separator}${className}::${pseudo}`
+        return `.${e(`${pseudo}${separator}${className}`)}::${pseudo}`
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-pseudo-elements",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TailwindCSS Plugin that adds variants of pseudo elements.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi,

Thanks for this great plugin.

I've added the escaping function ( e ) as described in the 1.x documentation so that class names are properly escaped and don't generate errors when compiling. Without this function, the plugin does not work properly.

Best regards,

-- 
Corentin Ribeyre